### PR TITLE
Update quarks-secret docs

### DIFF
--- a/content/en/docs/quarks-secret/_index.md
+++ b/content/en/docs/quarks-secret/_index.md
@@ -15,7 +15,7 @@ description: >
 
 ## Description
 
-A QuarksSecret lets you automatically generate secrets such as passwords, certificates and ssh keys, to ease management of credentials in Kubernetes.
+Quarks Secret lets you automatically generate secrets such as passwords, certificates and ssh keys, to ease management of credentials in Kubernetes.
 
 
 ## Installation
@@ -70,55 +70,30 @@ the `type` field denotes the type of secret that should be generated, currently 
 - `basic-auth`
 - `dockerconfigjson`
 - `copy`
+- `templatedconfig`
 
 ### Generate credentials
 
-`QuarksSecret` can be used to generate passwords, certificates and keys. It uses the [cfssl package](https://github.com/cloudflare/cfssl) to generate these. The generated values are stored in kubernetes secrets.
+Quarks Secret can be used to generate passwords, certificates and keys. It uses the [cfssl package](https://github.com/cloudflare/cfssl) to generate these. The generated values are stored in kubernetes secrets.
 
 #### Certificates
-Example of a `QuarksSecret` which generates a Kubernetes secret containing a certificate:
+
+Example of a `QuarksSecret` resource, which generates a Kubernetes secret containing a certificate:
+
 {{<githubembed repo="cloudfoundry-incubator/quarks-secret" file="docs/examples/certificate.yaml" lang="yaml">}}
 
 The example can be applied to the namespace where the operator is watching for resources ( `staging` by default )
 
+If a certificate is generated, the Quarks Secret operator ensures that a certificate signing request (CSR) is generated and is approved by the Kubernetes API server.
+
 #### RSA keys
+
 {{<githubembed repo="cloudfoundry-incubator/quarks-secret" file="docs/examples/rsa.yaml" lang="yaml">}}
 
 #### Basic Authentication
+
 {{<githubembed repo="cloudfoundry-incubator/quarks-secret" file="docs/examples/basic-auth.yml" lang="yaml">}}
 
-### Rotate credentials
-
-The generated credentials can be rotated by specifying its quarkssecret's name in a configmap. The configmap must have the label```quarks.cloudfoundry.org/secret-rotation```, for example as you can see in **Line 7**:
-{{<githubembed repo="cloudfoundry-incubator/quarks-secret" file="docs/examples/rotate.yaml" lang="yaml" options="hl_lines=7">}}
-
-### Approve Certificates
-
-In the case, where a certificate is generated, the QuarksSecret ensures that a certificate signing request is generated and is approved by the Kubernetes API server.
-
-
-### Secret copy
-
-The Quarks Secret operator can generate also copies in multiple namespaces while generating secrets.
-
-For example, while generating passwords:
-
-{{<githubembed repo="cloudfoundry-incubator/quarks-secret" file="docs/examples/copy.yaml" lang="yaml" >}}
-
-It can be specified a  list of copying target, with `copies`:
-
-```yaml
-  copies:
-  - name: copied-secret
-    namespace: namespace1
-```
-
-And each destination which is indicated needs to have a `Quarks Secret` of `copy` in the following form:
-
-{{<githubembed repo="cloudfoundry-incubator/quarks-secret" file="docs/examples/copy-qsecret-destination.yaml" lang="yaml" >}}
-
-
-The examples copies the generated `gen-secret` secret content into `copied-secret`  inside the `COPYNAMESPACE` namespace.
 
 ## Examples
 

--- a/content/en/docs/quarks-secret/development/_index.md
+++ b/content/en/docs/quarks-secret/development/_index.md
@@ -3,26 +3,26 @@ title: "Development"
 linkTitle: "Development"
 weight: 40
 description: >
-  A QuarksSecret generates passwords, keys and certificates and stores them in Kubernetes secrets.
+  Quarks Secret generates passwords, keys and certificates and stores them in Kubernetes secrets.
 ---
 
 ## Description
 
-A QuarksSecret generates passwords, keys and certificates and stores them in Kubernetes secrets.
+Quarks Secret generates passwords, keys and certificates and stores them in Kubernetes secrets.
 
-## QuarksSecret Component
+## Quarks Secret Component
 
-The **QuarksSecret** component consists of three controllers, each with a separate reconciliation loop.
+The **Quarks Secret** component consists of three controllers, each with a separate reconciliation loop.
 
 Figure 1, illustrates the component and associated set of controllers.
 
 ![qsec-component-flow](quarks_eseccomponent_flow.png)
-*Fig. 1: The QuarksSecret component*
+*Fig. 1: The Quarks Secret component*
 
-### **_QuarksSecret Controller_**
+### **_Quarks Secret Controller_**
 
 ![qsec-controller-flow](quarks_eseccontroller_flow.png)
-*Fig. 2: The QuarksSecret controller*
+*Fig. 2: The Quarks Secret controller*
 
 
 #### Watches in Quarks Secret Controller
@@ -40,7 +40,7 @@ Figure 1, illustrates the component and associated set of controllers.
 
 ##### Types
 
-Depending on the `spec.type`, `QuarksSecret` supports generating the following:
+Depending on the `spec.type`, Quarks Secret supports generating the following:
 
 | Secret Type                     | spec.type     | certificate.signerType | certificate.isCA |
 | ------------------------------- | ------------- | ---------------------- | ---------------- |
@@ -58,7 +58,7 @@ Depending on the `spec.type`, `QuarksSecret` supports generating the following:
 
 ##### Auto-approving Certificates
 
-A certificate `QuarksSecret` can be signed by the Kubernetes API Server. The **QuarksSecret** Controller is responsible for generating the certificate signing request:
+A certificate `QuarksSecret` resource can be signed by the Kubernetes API Server. The **Quarks Secret** Controller is responsible for generating the certificate signing request:
 
 ```yaml
 apiVersion: certificates.k8s.io/v1beta1
@@ -74,7 +74,7 @@ spec:
 
 ##### Copies
 
-The `QuarksSecret` controller can create copies of a generated secret or a user created secret across multiple namespaces, as long as the target secrets or target `QuarksSecret` with type `copy` (that live in a namespace other than the namespace of the `QuarksSecret`) already exist. If it is a generated secret in the source namespace, then the secret or `QuarksSecret` in target namespace shoud have the following annotaton
+The Quarks Secret controller can create copies of a generated secret or a user created secret across multiple namespaces, as long as the target secrets or target `QuarksSecret` with type `copy` (that live in a namespace other than the namespace of the `QuarksSecret`) already exist. If it is a generated secret in the source namespace, then the secret or `QuarksSecret` in target namespace shoud have the following annotaton
 
 ```text
 quarks.cloudfoundry.org/secret-copy-of: NAMESPACE/SOURCE_QUARKS_SECRET_NAME
@@ -124,14 +124,14 @@ The secret rotation controller watches for a rotation config map and re-generate
 #### Reconciliation in Secret Rotation Controller
 
 - Will read the array of `QuarksSecret` names from the JSON under the config map key `secrets`.
-- Skip `QuarksSecret` where `.status.generated` is `false`, as these might be under control of the user.
+- Skip `QuarksSecret` where `.status.generated` is set and `false`
 - Set `.status.generated` for each named `QuarksSecret` to `false`, to trigger re-creation of the corresponding secret.
 
 ## Relationship With the BDPL Component
 
-All explicit variables of a BOSH manifest will be created as `QuarksSecret` instances, which will trigger the **QuarksSecret** Controller.
+All explicit variables of a BOSH manifest will be created as `QuarksSecret` instances, which will trigger the **Quarks Secret** Controller.
 This will create corresponding secrets. If the user decides to change a secret, the `.status.generated` field in the corresponding `QuarksSecret` should be set to `false`, to protect against overwriting.
 
-## `QuarksSecret` Examples
+## Examples
 
 See https://github.com/cloudfoundry-incubator/quarks-secret/tree/master/docs/examples

--- a/content/en/docs/quarks-secret/tasks.md
+++ b/content/en/docs/quarks-secret/tasks.md
@@ -1,0 +1,53 @@
+---
+title: "Tasks"
+linkTitle: "Tasks"
+weight: 30
+description: >
+  Working with QuarksSecret
+---
+
+
+## User Provided Secrets
+
+To skip generation of secrets and provide custom values, create the secret first.
+
+{{<githubembed repo="cloudfoundry-incubator/quarks-secret" file="docs/examples/user-provided-secret.yaml" lang="yaml">}}
+
+Quarks Secret will skip existing secrets of the same name.
+Generated secrets have the `quarks.cloudfoundry.org/secret-kind=generated` label.
+
+## Rotation Config
+
+The generated secret values can be updated by creating a special 'rotation config' config map.
+The configmap must have the label `quarks.cloudfoundry.org/secret-rotation`.
+
+The rotation config specifies a list of QuarksSecret names:
+
+{{<githubembed repo="cloudfoundry-incubator/quarks-secret" file="docs/examples/rotate.yaml" lang="yaml" options="hl_lines=9">}}
+
+After creation of the config map, the generated secrets of the listed QuarksSecrets will be updated. Updates to the rotation config are ignored, it has to be deleted and created again for another rotation run.
+
+If a secret is missing the `quarks.cloudfoundry.org/secret-kind=generated` it will not be changed.
+
+## Copy Secrets Into Another Namespace
+
+The Quarks Secret operator can also generate copies in multiple namespaces while generating secrets.
+
+For example, while generating passwords:
+
+{{<githubembed repo="cloudfoundry-incubator/quarks-secret" file="docs/examples/copy.yaml" lang="yaml" >}}
+
+A list of copying targets can be specified with the `copies` key:
+
+```yaml
+  copies:
+  - name: copied-secret
+    namespace: namespace1
+```
+
+As a safeguard against incidential updates, each indicated destination needs to have a `QuarksSecret` of the `copy` type in the following form:
+
+{{<githubembed repo="cloudfoundry-incubator/quarks-secret" file="docs/examples/copy-qsecret-destination.yaml" lang="yaml" >}}
+
+
+The example copies the generated `gen-secret` secret content into `copied-secret`  inside the `COPYNAMESPACE` namespace.


### PR DESCRIPTION
Adds tasks, to explain how to work with quarks-secret.
Adds docs for rotating secrets and "user-provided" secrets.


Depends on: https://github.com/cloudfoundry-incubator/quarks-secret/pull/46

[#174356415](https://www.pivotaltracker.com/story/show/174356415)