### PR TITLE
Add "tls" QuarksSecret type

### DIFF
--- a/content/en/docs/quarks-secret/_index.md
+++ b/content/en/docs/quarks-secret/_index.md
@@ -65,6 +65,7 @@ the `type` field denotes the type of secret that should be generated, currently 
 
 - `password`
 - `certificate`
+- `tls`
 - `ssh`
 - `rsa`
 - `basic-auth`
@@ -85,6 +86,15 @@ Example of a `QuarksSecret` resource, which generates a Kubernetes secret contai
 The example can be applied to the namespace where the operator is watching for resources ( `staging` by default )
 
 If a certificate is generated, the Quarks Secret operator ensures that a certificate signing request (CSR) is generated and is approved by the Kubernetes API server.
+
+#### k8s TLS
+
+{{<githubembed repo="cloudfoundry-incubator/quarks-secret" file="docs/examples/tls.yaml" lang="yaml">}}
+
+This `QuarksSecret` resource example generates a Kubernetes Secret of [kubernetes.io/tls](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) type,
+which contains keys named `tls.crt` and `tls.key` that contain the certificate and private key to use for TLS.
+It is primarily used with TLS termination of the k8s `Ingress` resource or [Istio Secure Gateways](https://istio.io/latest/docs/tasks/traffic-management/ingress/secure-ingress/).
+Due to its use cases, only local `signerType` is supported.
 
 #### RSA keys
 

--- a/content/en/docs/quarks-secret/development/_index.md
+++ b/content/en/docs/quarks-secret/development/_index.md
@@ -44,13 +44,13 @@ Depending on the `spec.type`, Quarks Secret supports generating the following:
 
 | Secret Type                     | spec.type     | certificate.signerType | certificate.isCA |
 | ------------------------------- | ------------- | ---------------------- | ---------------- |
-| `passwords`                     | `password`    | not set                | not set          |
-| `username-password pairs`       | `basic-auth`  | not set                | not set          |
-| `rsa keys`                      | `rsa`         | not set                | not set          |
-| `ssh keys`                      | `ssh`         | not set                | not set          |
-| `self-signed root certificates` | `certificate` | `local`                | `true`           |
-| `self-signed certificates`      | `certificate` | `local`                | `false`          |
-| `cluster-signed certificates`   | `certificate` | `cluster`              | `false`          |
+| passwords                       | `password`    | not set                | not set          |
+| username-password pairs         | `basic-auth`  | not set                | not set          |
+| rsa keys                        | `rsa`         | not set                | not set          |
+| ssh keys                        | `ssh`         | not set                | not set          |
+| self-signed root certificates   | `certificate` | `local`                | `true`           |
+| self-signed certificates        | `certificate` | `local`                | `false`          |
+| cluster-signed certificates     | `certificate` | `cluster`              | `false`          |
 
 > **Note:**
 >

--- a/content/en/docs/quarks-secret/development/_index.md
+++ b/content/en/docs/quarks-secret/development/_index.md
@@ -51,6 +51,7 @@ Depending on the `spec.type`, Quarks Secret supports generating the following:
 | self-signed root certificates   | `certificate` | `local`                | `true`           |
 | self-signed certificates        | `certificate` | `local`                | `false`          |
 | cluster-signed certificates     | `certificate` | `cluster`              | `false`          |
+| k8s TLS (`kubernetes.io/tls`)   | `tls`         | `local`                | `false`          |
 
 > **Note:**
 >


### PR DESCRIPTION
- Add "tls" QuarksSecret type ([code change PR](https://github.com/cloudfoundry-incubator/quarks-secret/pull/45))
- The "Secret Type" column is the English descriptions of the types, not code; hence they should not be surrounded by back-ticks.

Co-authored-by: Bruce Ricard <bricard@vmware.com>